### PR TITLE
Add support for Monthly Statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: mixed-line-ending
     - id: requirements-txt-fixer
     - id: trailing-whitespace
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.1
   hooks:
     - id: flake8
@@ -23,6 +23,6 @@ repos:
     - id: bandit
       args: [--exclude, tests]
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.8.0
+  rev: 5.12.0
   hooks:
     - id: isort

--- a/pyitau/main.py
+++ b/pyitau/main.py
@@ -81,7 +81,41 @@ class Itau:
         response = self._session.post(
             ROUTER_URL,
             data={'periodoConsulta': days},
-            headers={'op': full_statement_page.filter_statements_op},
+            headers={'op': full_statement_page.filter_statements_by_period_op},
+        )
+        return response.json()
+
+    def get_statements_from_month(self, month: int = 1, year: int = 2001):
+        """
+        Get and return the full statements of a specific month.
+        """
+        if year < 2001:
+            raise Exception(f"Invalid year {year}.")
+
+        if month < 1 or month > 12:
+            raise Exception(f"Invalid month {month}.")
+
+        headers = {'op': self._home.op, 'segmento': 'VAREJO'}
+
+        response = self._session.post(ROUTER_URL, headers=headers)
+        menu = MenuPage(response.text)
+
+        response = self._session.post(ROUTER_URL, headers={'op': menu.checking_account_op})
+        account_menu = CheckingAccountMenu(response.text)
+
+        response = self._session.post(ROUTER_URL, headers={'op': account_menu.statements_op})
+        statements_page = CheckingAccountStatementsPage(response.text)
+
+        response = self._session.post(
+            ROUTER_URL,
+            headers={'op': statements_page.full_statement_op},
+        )
+        full_statement_page = CheckingAccountFullStatement(response.text)
+
+        response = self._session.post(
+            ROUTER_URL,
+            data={'mesCompleto': "%02d/%d" % (month, year)},
+            headers={'op': full_statement_page.filter_statements_by_month_op},
         )
         return response.json()
 

--- a/pyitau/pages.py
+++ b/pyitau/pages.py
@@ -183,9 +183,16 @@ class CardsPage(SoupPage):
 
 class CheckingAccountFullStatement(TextPage):
     @property
-    def filter_statements_op(self):
+    def filter_statements_by_period_op(self):
         pattern = 'function consultarLancamentosPorPeriodo.*' \
-                  '"periodoConsulta" : parametrosPeriodo.*' \
+                  '"periodoConsulta" : parametrosPeriodo.*?' \
+                  'url = "(.*?)";'
+        return re.search(pattern, self._text, flags=re.DOTALL).group(1)
+
+    @property
+    def filter_statements_by_month_op(self):
+        pattern = 'function consultarLancamentosPorPeriodo.*' \
+                  '"mesCompleto" : parametrosPeriodo.*?' \
                   'url = "(.*?)";'
         return re.search(pattern, self._text, flags=re.DOTALL).group(1)
 

--- a/tests/responses/checking_account_full_statement.html
+++ b/tests/responses/checking_account_full_statement.html
@@ -15,7 +15,7 @@
 				};
 				filtro.mesCompleto = parametrosPeriodo;
 				filtro.periodoConsulta = null;
-				url = "RANDOM_STRING=;";
+				url = "PYITAU_OP_MONTH_filter_statements=;";
 
 			} else {
 
@@ -30,7 +30,7 @@
 				parametros = {
 					"periodoConsulta" : parametrosPeriodo
 				};
-				url = "PYITAU_OP_filter_statements=;";
+				url = "PYITAU_OP_PERIOD_filter_statements=;";
 				
 				armazenaValoresFiltro("periodoVisualizacao", filtroLancamentos.filtroSelecionado().periodoConsulta);
 			}

--- a/tests/test_checking_account_full_statement_page.py
+++ b/tests/test_checking_account_full_statement_page.py
@@ -15,5 +15,9 @@ def page(response):
     return CheckingAccountFullStatement(response)
 
 
-def test_op(page):
-    assert page.filter_statements_op == 'PYITAU_OP_filter_statements=;'
+def test_period_op(page):
+    assert page.filter_statements_by_period_op == 'PYITAU_OP_PERIOD_filter_statements=;'
+
+
+def test_month_op(page):
+    assert page.filter_statements_by_month_op == 'PYITAU_OP_MONTH_filter_statements=;'


### PR DESCRIPTION
## Context

Currently, the package only supports getting statements from a limited number of days. However, the Itaú interface allow to fetch statements from a specific month.

## Suggestion

In order to allow a historical query of old statements, create a new flux which request statements from a specific month.

## Implementations

* Adjust **.pre-commit-config.yaml**
  * [flake8 error due migration](https://stackoverflow.com/questions/74843772/pre-commit-suddenly-fails-to-install-flake8)
  * [pre-commit incompatibilities with isord < 5.12.0 ](https://github.com/home-assistant/core/issues/86892)
* Implement function feature for `get_statements_from_month`  
* Update tests to cover new feature